### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "images"
   ],
   "description": "Import multiview image groups connected via user defined tag",
-  "docker_image": "supervisely/import-export:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",
   "modal_template_state": {

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "images"
   ],
   "description": "Import multiview image groups connected via user defined tag",
-  "docker_image": "supervisely/import-export:6.73.293",
+  "docker_image": "supervisely/import-export:6.73.564",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",
   "modal_template_state": {

--- a/config.json
+++ b/config.json
@@ -20,7 +20,7 @@
   "icon_cover": false,
   "icon_background": "#FFFFFF",
   "headless": true,
-  "min_instance_version": "6.12.28",
+  "instance_version": "6.15.60",
   "context_menu": {
     "target": [
       "files_folder",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.293
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
